### PR TITLE
fix: missing LinxISA target linkage dependency of `Passes`

### DIFF
--- a/llvm/lib/Target/LinxISA/CMakeLists.txt
+++ b/llvm/lib/Target/LinxISA/CMakeLists.txt
@@ -36,6 +36,7 @@ add_llvm_target(LinxISACodeGen
   LinxISADesc
   LinxISAInfo
   MC
+  Passes
   SelectionDAG
   Support
   Target


### PR DESCRIPTION
When `lld` is used on linux, it complains that symbols defined in `lib/Passes/OptimizationLevel.cpp` are not found. This commit adds the missing dependency back.